### PR TITLE
관람객, 티켓부스 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(8)
     }
 }
 

--- a/src/main/java/chapter_01/Audience.java
+++ b/src/main/java/chapter_01/Audience.java
@@ -8,7 +8,24 @@ public class Audience {
         this.bag = bag;
     }
 
-    public Bag getBag() {
-        return bag;
+    public Long buy(Ticket ticket) {
+        System.out.println("--- 초대장 확인 중");
+
+        if(bag.hasInvitation()) {
+            bag.setTicket(ticket);
+            System.out.println("--- 초대장 확인 완료 - 티켓 교환");
+            return 0L;
+        }
+
+        System.out.println("--- 초대장 없음으로 티켓 구매 중");
+
+        bag.minusAmount(ticket.getFee());
+        bag.setTicket(ticket);
+
+        return ticket.getFee();
+    }
+
+    public boolean hasTicket() {
+        return bag.hasTicket();
     }
 }

--- a/src/main/java/chapter_01/Audience.java
+++ b/src/main/java/chapter_01/Audience.java
@@ -9,8 +9,6 @@ public class Audience {
     }
 
     public Long buy(Ticket ticket) {
-        System.out.println("--- 초대장 확인 중");
-
         if(bag.hasInvitation()) {
             bag.setTicket(ticket);
             System.out.println("--- 초대장 확인 완료 - 티켓 교환");

--- a/src/main/java/chapter_01/TicketSeller.java
+++ b/src/main/java/chapter_01/TicketSeller.java
@@ -9,6 +9,7 @@ public class TicketSeller {
     }
 
     public void sellTo(Audience audience) {
+        System.out.println("--- 초대장을 확인합니다.");
         Ticket ticket = ticketOffice.getTicket();
         Long amount = audience.buy(ticket);
         ticketOffice.plusAmount(amount);

--- a/src/main/java/chapter_01/TicketSeller.java
+++ b/src/main/java/chapter_01/TicketSeller.java
@@ -9,21 +9,8 @@ public class TicketSeller {
     }
 
     public void sellTo(Audience audience) {
-        System.out.println("관중 입장 시작");
-        System.out.println("--- 초대장 확인 중");
-
-        if(audience.getBag().hasInvitation()) {
-            Ticket ticket = ticketOffice.getTicket();
-            audience.getBag().setTicket(ticket);
-            System.out.println("초대장 확인 - 표 발급");
-            return;
-        }
-
         Ticket ticket = ticketOffice.getTicket();
-        audience.getBag().minusAmount(ticket.getFee());
-        ticketOffice.plusAmount(ticket.getFee());
-        audience.getBag().setTicket(ticket);
-
-        System.out.println("표 발급");
+        Long amount = audience.buy(ticket);
+        ticketOffice.plusAmount(amount);
     }
 }

--- a/src/test/java/chapter_01/AudienceTest.java
+++ b/src/test/java/chapter_01/AudienceTest.java
@@ -1,0 +1,52 @@
+package chapter_01;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AudienceTest {
+
+    @Test
+    @DisplayName("초대장 없음 - 구매 성공 테스트")
+    void 초대장_없음_구매_성공_테스트() throws Exception {
+        // given
+        Bag bag = new Bag(1000L);
+        Audience audience = new Audience(bag);
+
+        // when
+        Long amount = audience.buy(new Ticket(1000L));
+
+        // then
+        Assertions.assertThat(amount).isEqualTo(1000L);
+        Assertions.assertThat(audience.hasTicket()).isTrue();
+    }
+
+    @Test
+    @DisplayName("초대장 소지 - 구매 성공 테스트")
+    void 초대장_소지_구매_성공_테스트() throws Exception {
+        // given
+        Bag bag = new Bag(1000L, new Invitation());
+        Audience audience = new Audience(bag);
+
+        // when
+        Long amount = audience.buy(new Ticket(1000L));
+
+        // then
+        Assertions.assertThat(amount).isEqualTo(0L);
+        Assertions.assertThat(audience.hasTicket()).isTrue();
+    }
+
+    @Test
+    @DisplayName("소지금 부족 - 구매 실패 테스트")
+    void 구매_실패_테스트_소지금_부족() throws Exception {
+        // given
+        Bag bag = new Bag(0L);
+        Audience audience = new Audience(bag);
+
+        // when then
+        Assertions.assertThatThrownBy(() -> audience.buy(new Ticket(1000L)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/chapter_01/TicketOfficeTest.java
+++ b/src/test/java/chapter_01/TicketOfficeTest.java
@@ -1,25 +1,32 @@
 package chapter_01;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class TicketOfficeTest {
 
     @Test
-    void getTicketTest() throws Exception {
+    @DisplayName("티켓 발급 성공 테스트")
+    void 티켓_발급_성공_테스트() throws Exception {
         // given
-        TicketOffice ticketOffice = new TicketOffice(50000L, new Ticket(1000L), new Ticket(2000L));
+        TicketOffice ticketOffice = new TicketOffice(50000L, new Ticket(1000L));
 
         // when
         Ticket ticket = ticketOffice.getTicket();
 
-        //then
+        // then
+        Assertions.assertThat(ticket).isNotNull();
     }
 
     @Test
-    void minusAmount() throws Exception {
-    }
+    @DisplayName("티켓 발급 실패 테스트 (티켓 부스에 남은 티켓 없음)")
+    void 티켓_발급_실패_테스트() throws Exception {
+        // given
+        TicketOffice ticketOffice = new TicketOffice(50000L);
 
-    @Test
-    void plusAmount() throws Exception {
+        // when then
+        Assertions.assertThatThrownBy(() -> ticketOffice.getTicket())
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/chapter_01/TicketSellerTest.java
+++ b/src/test/java/chapter_01/TicketSellerTest.java
@@ -25,8 +25,7 @@ class TicketSellerTest {
             ticketSeller.sellTo(audience);
 
             // then
-            Assertions.assertThat(audience.getBag().hasTicket()).isTrue();
-            Assertions.assertThat(audience.getBag().getAmount()).isEqualTo(0);
+            Assertions.assertThat(audience.hasTicket()).isTrue();
         }
 
         @Test
@@ -76,8 +75,7 @@ class TicketSellerTest {
             ticketSeller.sellTo(audience);
 
             // then
-            Assertions.assertThat(audience.getBag().hasTicket()).isTrue();
-            Assertions.assertThat(audience.getBag().getAmount()).isEqualTo(1000);
+            Assertions.assertThat(audience.hasTicket()).isTrue();
         }
 
         @Test


### PR DESCRIPTION
###  관람객, 티켓 부스 테스트 추가 
+ 관람객
  + 티켓 구매 성공 테스트
    + 초대장 소지
    + 초대장 소지 안함
  + 티켓 구매 실패 테스트
    + 소지금 부족

+ 티켓 부스
  + 티켓 발급 성공 테스트
  + 티켓 발급 실패 테스트

+ 티켓 판매원
  + 티켓 판매 테스트에서 검증 결과로 관람객이 티켓을 소지한지 여부만 판단하도록 수정
  + 티켓 판매원은 관람객의 남은 소지금에 관심이 없기때문에 위와 같이 관심사를 변경하였다.